### PR TITLE
feat: function to load config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -1,15 +1,48 @@
 package config
 
-type GlobalConfig struct {
-	NodeNumber int
+import (
+	"os"
+
+	"gopkg.in/yaml.v2"
+)
+
+type Config struct {
+	ConfigServer `yaml:"Server"`
+	ConfigNode `yaml:"Node"`
 }
 
-var DefaultConfig = GlobalConfig{
-	NodeNumber: 5,
+type ConfigServer struct {
+	Host string `yaml:"Host"`
+	Port int `yaml:"Port"`
 }
 
-func LoadConfig() *GlobalConfig {
-	cfg := &GlobalConfig{}
-	*cfg = DefaultConfig
-	return cfg
+type ConfigNode struct {
+	Number int `yaml:"Number"`
 }
+
+var configPath = "../config.yaml"
+
+// It loads the config from YAML file and return the config object
+func LoadConfig() (*Config, error) {
+	cfg := &Config{}
+
+	file, err := os.Open(configPath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+	
+	d := yaml.NewDecoder(file)
+
+	if err := d.Decode(&cfg); err != nil {
+		return nil, err
+	}
+
+	return cfg, nil
+}
+
+// Custom compare function for nested struct
+func (config *Config) IsEqual(xConfig *Config) bool {
+	return config.ConfigServer == xConfig.ConfigServer && config.ConfigNode == xConfig.ConfigNode 
+}
+

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -1,0 +1,25 @@
+package config
+
+import (
+	"testing"
+)
+
+var expectedConfig = &Config{
+	ConfigServer: ConfigServer{
+		Host: "localhost",
+		Port: 8080,
+	},
+	ConfigNode: ConfigNode{
+		Number: 5,
+	},
+}
+
+func TestLoadConfig(t *testing.T) {
+	config, err := LoadConfig()
+	if err != nil {
+		t.Error(err)
+	}
+	if !config.IsEqual(expectedConfig) {
+		t.Errorf("Expected: %v, instead received: %v", expectedConfig, config)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,5 @@
-module "github.com/xmliszt/e-safe"
+module github.com/xmliszt/e-safe
 
 go 1.15
+
+require gopkg.in/yaml.v2 v2.4.0

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,3 @@
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=


### PR DESCRIPTION
- Configuration can be set up via the `config.yaml` file in the root directory
- Under `config/` directory, can use `LoadConfig` to load the config for the project
- Unit test for `LoadConfig` is set up under `config/` folder as well, currently, the test cases are **hard-coded**, can consider changing to dynamic by reading from YAML file instead in the future